### PR TITLE
Add staged PyTorch build workflow

### DIFF
--- a/.github/workflows/pytorch-staged.yml
+++ b/.github/workflows/pytorch-staged.yml
@@ -1,0 +1,181 @@
+name: Build and Push PyTorch in Stages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-base:
+    name: Build Base Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        env:
+          - {
+              OS_VERSION: "24.04",
+              TORCH: "2.7.1",
+              VISION: "0.22.1",
+              AUDIO: "2.7.1",
+              MUJOCO: "3.3.3",
+              GYM: "1.2.0",
+              CUDA: "12.8.0",
+              TAG: "cuda12.8-torch2.7"
+            }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/pytorch/Dockerfile
+          push: true
+          target: base
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-base
+          build-args: |
+            BASE_IMAGE=nvidia/cuda:${{ matrix.env.CUDA }}-cudnn-devel-ubuntu${{ matrix.env.OS_VERSION }}
+
+  build-mujoco:
+    name: Install MuJoCo and Gymnasium
+    runs-on: ubuntu-latest
+    needs: build-base
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        env:
+          - {
+              OS_VERSION: "24.04",
+              TORCH: "2.7.1",
+              VISION: "0.22.1",
+              AUDIO: "2.7.1",
+              MUJOCO: "3.3.3",
+              GYM: "1.2.0",
+              CUDA: "12.8.0",
+              TAG: "cuda12.8-torch2.7"
+            }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build mujoco stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/pytorch/Dockerfile
+          push: true
+          target: mujoco
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-mujoco
+          build-args: |
+            BASE_IMAGE_MUJOCO=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-base
+            MUJOCO_VERSION=${{ matrix.env.MUJOCO }}
+            GYM_VERSION=${{ matrix.env.GYM }}
+
+  build-pytorch:
+    name: Install PyTorch
+    runs-on: ubuntu-latest
+    needs: build-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        env:
+          - {
+              OS_VERSION: "24.04",
+              TORCH: "2.7.1",
+              VISION: "0.22.1",
+              AUDIO: "2.7.1",
+              MUJOCO: "3.3.3",
+              GYM: "1.2.0",
+              CUDA: "12.8.0",
+              TAG: "cuda12.8-torch2.7"
+            }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build pytorch stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/pytorch/Dockerfile
+          push: true
+          target: pytorch
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-pytorch
+          build-args: |
+            BASE_IMAGE_MUJOCO=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-base
+            BASE_IMAGE_PYTORCH=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-mujoco
+            TORCH_VERSION=${{ matrix.env.TORCH }}
+            TORCHVISION_VERSION=${{ matrix.env.VISION }}
+            TORCHAUDIO_VERSION=${{ matrix.env.AUDIO }}
+
+  finalize:
+    name: Final Image With User
+    runs-on: ubuntu-latest
+    needs: build-pytorch
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        env:
+          - {
+              OS_VERSION: "24.04",
+              TORCH: "2.7.1",
+              VISION: "0.22.1",
+              AUDIO: "2.7.1",
+              MUJOCO: "3.3.3",
+              GYM: "1.2.0",
+              CUDA: "12.8.0",
+              TAG: "cuda12.8-torch2.7"
+            }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/pytorch/Dockerfile
+          push: true
+          target: final
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}
+          build-args: |
+            BASE_IMAGE_MUJOCO=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-base
+            BASE_IMAGE_PYTORCH=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-mujoco
+            BASE_IMAGE_FINAL=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.env.TAG }}-pytorch
+            MUJOCO_VERSION=${{ matrix.env.MUJOCO }}
+            GYM_VERSION=${{ matrix.env.GYM }}
+            TORCH_VERSION=${{ matrix.env.TORCH }}
+            TORCHVISION_VERSION=${{ matrix.env.VISION }}
+            TORCHAUDIO_VERSION=${{ matrix.env.AUDIO }}

--- a/creator/pytorch/Dockerfile
+++ b/creator/pytorch/Dockerfile
@@ -1,8 +1,10 @@
 # Dockerfile for PyTorch + MuJoCo + ROS2 Environment
 
-# Base image setup
+# -----------------------------------------------------------------------------
+# Stage 1: base image
+# -----------------------------------------------------------------------------
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 COPY creator/pytorch/bashrc /etc/bash.bashrc
@@ -10,7 +12,7 @@ RUN chmod a+rwx /etc/bash.bashrc
 ENV SHELL /bin/bash
 SHELL ["/bin/bash", "-c"]
 
-# Define build-time arguments
+# Define common build-time arguments
 ARG ROS_DISTRO
 ARG MUJOCO_VERSION=3.3.3
 ARG CPU_ARCH=x86_64
@@ -35,30 +37,44 @@ RUN apt-get update && \
         sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install MuJoCo
+# -----------------------------------------------------------------------------
+# Stage 2: install MuJoCo and Gymnasium
+# -----------------------------------------------------------------------------
+ARG BASE_IMAGE_MUJOCO=base
+FROM ${BASE_IMAGE_MUJOCO} AS mujoco
+
 RUN mkdir -p ${MUJOCO_DIR} /home/mujoco && \
     wget https://github.com/google-deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz && \
     tar -xzf mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz -C $(dirname ${MUJOCO_DIR}) && \
     rm mujoco-${MUJOCO_VERSION}-linux-${CPU_ARCH}.tar.gz
 
-# Install Python packages
 RUN apt-get update && \
     apt-get install -y python3-venv && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip
 
-# Update PATH to use venv Python
 ENV PATH="/opt/venv/bin:$PATH"
 RUN source /opt/venv/bin/activate && \
     pip3 install --upgrade pip && \
     pip3 install --no-cache-dir gradio tensorboard mujoco==${MUJOCO_VERSION} gymnasium==${GYM_VERSION}
 
-# Conditionally install PyTorch packages
+# -----------------------------------------------------------------------------
+# Stage 3: install PyTorch
+# -----------------------------------------------------------------------------
+ARG BASE_IMAGE_PYTORCH=mujoco
+FROM ${BASE_IMAGE_PYTORCH} AS pytorch
+
 RUN source /opt/venv/bin/activate && \
     pip3 install --no-cache-dir torch==${TORCH_VERSION} \
     torchvision${TORCHVISION_VERSION:+==${TORCHVISION_VERSION}} \
     torchaudio${TORCHAUDIO_VERSION:+==${TORCHAUDIO_VERSION}} \
     --index-url ${TORCH_INDEX_URL}
+
+# -----------------------------------------------------------------------------
+# Stage 4: create user and final image
+# -----------------------------------------------------------------------------
+ARG BASE_IMAGE_FINAL=pytorch
+FROM ${BASE_IMAGE_FINAL} AS final
 
 # Setup non-root admin user
 ARG USERNAME=admin


### PR DESCRIPTION
## Summary
- add stages to creator/pytorch Dockerfile so each step can be built independently
- add new `pytorch-staged.yml` workflow demonstrating a multi-job build pipeline

## Testing
- `pre-commit run --files .github/workflows/pytorch-staged.yml creator/pytorch/Dockerfile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec257a9f48324ae1319d8bc67812a