### PR TITLE
Add staged ROS2 build workflow

### DIFF
--- a/.github/workflows/ros2-staged.yml
+++ b/.github/workflows/ros2-staged.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
     paths:
       - 'creator/**'
+  pull_request:
+    branches: [ main ]
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/ros2-staged.yml
+++ b/.github/workflows/ros2-staged.yml
@@ -1,0 +1,198 @@
+name: Build and Push ROS2 Images in Stages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'creator/**'
+  schedule:
+    - cron: '0 0 * * 0'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  base_ros_user:
+    name: Ubuntu -> ROS -> user
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base layer
+        run: docker build -f creator/common/Dockerfile.base --build-arg BASE_IMAGE=${{ matrix.os }} -t base:${{ matrix.os }} .
+      - name: Build ROS layer
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}
+          else
+            ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}
+          fi
+          docker build -f $ROS_FILE --build-arg BASE_IMAGE=base:${{ matrix.os }} -t ros:${{ matrix.os }}-${{ matrix.ros }} .
+      - name: Build final user image
+        run: |
+          docker build -f creator/common/Dockerfile.user --build-arg BASE_IMAGE=ros:${{ matrix.os }}-${{ matrix.ros }} -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }} .
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}
+
+  base_ros_moveit_user:
+    name: Ubuntu -> ROS -> MoveIt -> user
+    runs-on: ubuntu-latest
+    needs: base_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base layer
+        run: docker build -f creator/common/Dockerfile.base --build-arg BASE_IMAGE=${{ matrix.os }} -t base:${{ matrix.os }} .
+      - name: Build ROS layer
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}
+          else
+            ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}
+          fi
+          docker build -f $ROS_FILE --build-arg BASE_IMAGE=base:${{ matrix.os }} -t ros:${{ matrix.os }}-${{ matrix.ros }} .
+      - name: Add MoveIt
+        run: |
+          docker build -f creator/usage/Dockerfile.moveit --build-arg BASE_IMAGE=ros:${{ matrix.os }}-${{ matrix.ros }} --build-arg ROS_DISTRO=${{ matrix.ros }} -t moveit:${{ matrix.os }}-${{ matrix.ros }} .
+      - name: Build final user image
+        run: docker build -f creator/common/Dockerfile.user --build-arg BASE_IMAGE=moveit:${{ matrix.os }}-${{ matrix.ros }} -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-moveit .
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-moveit
+
+  mujoco_ros_user:
+    name: Ubuntu -> MuJoCo -> ROS -> user
+    runs-on: ubuntu-latest
+    needs: base_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base layer
+        run: docker build -f creator/common/Dockerfile.base --build-arg BASE_IMAGE=${{ matrix.os }} -t base:${{ matrix.os }} .
+      - name: Install MuJoCo
+        run: docker build -f composer/mujoco/Dockerfile --build-arg BASE_IMAGE=base:${{ matrix.os }} --build-arg ROS_DISTRO=${{ matrix.ros }} -t mujoco:${{ matrix.os }}-${{ matrix.ros }} composer/mujoco
+      - name: Build ROS layer
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}
+          else
+            ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}
+          fi
+          docker build -f $ROS_FILE --build-arg BASE_IMAGE=mujoco:${{ matrix.os }}-${{ matrix.ros }} -t ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco .
+      - name: Build final user image
+        run: docker build -f creator/common/Dockerfile.user --build-arg BASE_IMAGE=ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco .
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+
+  mujoco_ros_moveit_user:
+    name: Ubuntu -> MuJoCo -> ROS -> MoveIt -> user
+    runs-on: ubuntu-latest
+    needs: mujoco_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base layer
+        run: docker build -f creator/common/Dockerfile.base --build-arg BASE_IMAGE=${{ matrix.os }} -t base:${{ matrix.os }} .
+      - name: Install MuJoCo
+        run: docker build -f composer/mujoco/Dockerfile --build-arg BASE_IMAGE=base:${{ matrix.os }} --build-arg ROS_DISTRO=${{ matrix.ros }} -t mujoco:${{ matrix.os }}-${{ matrix.ros }} composer/mujoco
+      - name: Build ROS layer
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}
+          else
+            ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}
+          fi
+          docker build -f $ROS_FILE --build-arg BASE_IMAGE=mujoco:${{ matrix.os }}-${{ matrix.ros }} -t ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco .
+      - name: Add MoveIt
+        run: docker build -f creator/usage/Dockerfile.moveit --build-arg BASE_IMAGE=ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco --build-arg ROS_DISTRO=${{ matrix.ros }} -t moveit:${{ matrix.os }}-${{ matrix.ros }}-mujoco .
+      - name: Build final user image
+        run: docker build -f creator/common/Dockerfile.user --build-arg BASE_IMAGE=moveit:${{ matrix.os }}-${{ matrix.ros }}-mujoco -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-moveit .
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-moveit
+
+  mujoco_ros_nav2_user:
+    name: Ubuntu -> MuJoCo -> ROS -> Nav2 -> user
+    runs-on: ubuntu-latest
+    needs: mujoco_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base layer
+        run: docker build -f creator/common/Dockerfile.base --build-arg BASE_IMAGE=${{ matrix.os }} -t base:${{ matrix.os }} .
+      - name: Install MuJoCo
+        run: docker build -f composer/mujoco/Dockerfile --build-arg BASE_IMAGE=base:${{ matrix.os }} --build-arg ROS_DISTRO=${{ matrix.ros }} -t mujoco:${{ matrix.os }}-${{ matrix.ros }} composer/mujoco
+      - name: Build ROS layer
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}
+          else
+            ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}
+          fi
+          docker build -f $ROS_FILE --build-arg BASE_IMAGE=mujoco:${{ matrix.os }}-${{ matrix.ros }} -t ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco .
+      - name: Add Nav2
+        run: docker build -f creator/usage/Dockerfile.nav2 --build-arg BASE_IMAGE=ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco --build-arg ROS_DISTRO=${{ matrix.ros }} -t nav2:${{ matrix.os }}-${{ matrix.ros }}-mujoco .
+      - name: Build final user image
+        run: docker build -f creator/common/Dockerfile.user --build-arg BASE_IMAGE=nav2:${{ matrix.os }}-${{ matrix.ros }}-mujoco -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-nav2 .
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-nav2

--- a/creator/README.md
+++ b/creator/README.md
@@ -21,6 +21,12 @@
 - Example to run a Docker workspace with Ubuntu 22.04, ROS Humble, Navigation and Simulation enabled. However, you can attach your workspace to the container. This requires you to have a workspace in the same directory as the script. Or you can use the `-w` flag to specify the path to your workspace.
     - `./run_env.sh -o 22.04 -v humble -u navigation -s true -i my_image -w path_to_your_worspace -r`
 
+### Automated builds on GitHub
+ROS images are also built and published using the
+[`ros2-staged.yml`](../.github/workflows/ros2-staged.yml) workflow. The pipeline
+creates base images and optional MuJoCo, MoveIt or Nav2 variants for the
+available ROS distributions.
+
 # Docker Workspaces using VSCode devcontainer
 =============================================
 - Create a new folder named `.devcontainer` in your workspace and creat a file named `devcontainer.json` in it.


### PR DESCRIPTION
## Summary
- remove unused `build_ros2_env.sh`
- document automated ROS2 workflow in README
- add new `ros2-staged.yml` workflow to build ROS2 images in several jobs

## Testing
- `pre-commit run --files creator/README.md .github/workflows/ros2-staged.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eccdf6c388324a2702a5f09e1a9eb