### PR TITLE
Add multi-layer ROS build workflow

### DIFF
--- a/.github/workflows/ros2-staged.yml
+++ b/.github/workflows/ros2-staged.yml
@@ -1,0 +1,344 @@
+name: Build and Push ROS Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'creator/**'
+  schedule:
+    - cron: '0 0 * * 0'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  base_ros_user:
+    name: Ubuntu -> ROS -> user
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.os }}
+      - name: Select ROS Dockerfile
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            echo "ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          else
+            echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          fi
+      - name: Build ROS stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+      - name: Build final user image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+
+  base_ros_moveit_user:
+    name: Ubuntu -> ROS -> MoveIt -> user
+    runs-on: ubuntu-latest
+    needs: base_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.os }}
+      - name: Select ROS Dockerfile
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            echo "ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          else
+            echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          fi
+      - name: Build ROS stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+      - name: Add MoveIt
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/usage/Dockerfile.moveit
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+            ROS_DISTRO=${{ matrix.ros }}
+      - name: Build final user image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-moveit
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}
+
+  mujoco_ros_user:
+    name: Ubuntu -> MuJoCo -> ROS -> user
+    runs-on: ubuntu-latest
+    needs: base_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.os }}
+      - name: Install MuJoCo
+        uses: docker/build-push-action@v5
+        with:
+          context: composer/mujoco
+          file: composer/mujoco/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=base:${{ matrix.os }}
+            ROS_DISTRO=${{ matrix.ros }}
+      - name: Select ROS Dockerfile
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            echo "ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          else
+            echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          fi
+      - name: Build ROS stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}-${{ matrix.ros }}
+      - name: Build final user image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+
+  mujoco_ros_moveit_user:
+    name: Ubuntu -> MuJoCo -> ROS -> MoveIt -> user
+    runs-on: ubuntu-latest
+    needs: mujoco_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.os }}
+      - name: Install MuJoCo
+        uses: docker/build-push-action@v5
+        with:
+          context: composer/mujoco
+          file: composer/mujoco/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=base:${{ matrix.os }}
+            ROS_DISTRO=${{ matrix.ros }}
+      - name: Select ROS Dockerfile
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            echo "ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          else
+            echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          fi
+      - name: Build ROS stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}-${{ matrix.ros }}
+      - name: Add MoveIt
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/usage/Dockerfile.moveit
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+            ROS_DISTRO=${{ matrix.ros }}
+      - name: Build final user image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-moveit
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+
+  mujoco_ros_nav2_user:
+    name: Ubuntu -> MuJoCo -> ROS -> Nav2 -> user
+    runs-on: ubuntu-latest
+    needs: mujoco_ros_user
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["20.04", "22.04", "24.04"]
+        ros: [rolling, kilted, jazzy, humble, noetic]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.os }}
+      - name: Install MuJoCo
+        uses: docker/build-push-action@v5
+        with:
+          context: composer/mujoco
+          file: composer/mujoco/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=base:${{ matrix.os }}
+            ROS_DISTRO=${{ matrix.ros }}
+      - name: Select ROS Dockerfile
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            echo "ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          else
+            echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          fi
+      - name: Build ROS stage
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}-${{ matrix.ros }}
+      - name: Add Nav2
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/usage/Dockerfile.nav2
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nav2:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+            ROS_DISTRO=${{ matrix.ros }}
+      - name: Build final user image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-nav2
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nav2:${{ matrix.os }}-${{ matrix.ros }}-mujoco

--- a/.github/workflows/ros2-staged.yml
+++ b/.github/workflows/ros2-staged.yml
@@ -6,6 +6,10 @@ on:
     branches: [ main ]
     paths:
       - 'creator/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'creator/**'
   schedule:
     - cron: '0 0 * * 0'
 

--- a/creator/README.md
+++ b/creator/README.md
@@ -21,6 +21,12 @@
 - Example to run a Docker workspace with Ubuntu 22.04, ROS Humble, Navigation and Simulation enabled. However, you can attach your workspace to the container. This requires you to have a workspace in the same directory as the script. Or you can use the `-w` flag to specify the path to your workspace.
     - `./run_env.sh -o 22.04 -v humble -u navigation -s true -i my_image -w path_to_your_worspace -r`
 
+### Automated builds on GitHub
+ROS images are also built and published using the
+[`ros2-staged.yml`](../.github/workflows/ros2-staged.yml) workflow. The workflow
+uses multiple jobs to layer images with ROS itself and optional MuJoCo, MoveIt
+or Nav2 support across all supported Ubuntu and ROS version combinations.
+
 # Docker Workspaces using VSCode devcontainer
 =============================================
 - Create a new folder named `.devcontainer` in your workspace and creat a file named `devcontainer.json` in it.


### PR DESCRIPTION
## Summary
- create a staged workflow using docker/build-push-action for each ROS layer
- document layered ROS image workflow in README
- push intermediate images to the repo namespace

## Testing
- `pre-commit run --files .github/workflows/ros2-staged.yml creator/README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eccdf6c388324a2702a5f09e1a9eb