### PR TITLE
Refine ROS workflow

### DIFF
--- a/.github/workflows/ros2-staged.yml
+++ b/.github/workflows/ros2-staged.yml
@@ -1,0 +1,395 @@
+name: Build ROS Images in Stages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'creator/**'
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-base:
+    name: Build Base Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["24.04", "22.04", "20.04"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build base layer
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.base
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.os }}
+
+  build-ros:
+    name: Add ROS
+    runs-on: ubuntu-latest
+    needs: build-base
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+          - { os: "22.04", ros: humble }
+          - { os: "20.04", ros: noetic }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Select ROS Dockerfile
+        run: |
+          if [[ "${{ matrix.ros }}" == "noetic" || "${{ matrix.ros }}" == "kinetic" ]]; then
+            echo "ROS_FILE=creator/ros1/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          else
+            echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+          fi
+      - name: Build ROS layer
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+
+  build-moveit:
+    name: Add MoveIt
+    runs-on: ubuntu-latest
+    needs: build-ros
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+          - { os: "22.04", ros: humble }
+          - { os: "20.04", ros: noetic }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build MoveIt layer
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/usage/Dockerfile.moveit
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+            ROS_DISTRO=${{ matrix.ros }}
+
+  build-mujoco:
+    name: Add MuJoCo
+    runs-on: ubuntu-latest
+    needs: build-base
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        os: ["24.04"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build MuJoCo layer
+        uses: docker/build-push-action@v5
+        with:
+          context: composer/mujoco
+          file: composer/mujoco/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/base:${{ matrix.os }}
+
+  build-ros-mujoco:
+    name: MuJoCo + ROS
+    runs-on: ubuntu-latest
+    needs: build-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Select ROS Dockerfile
+        run: |
+          echo "ROS_FILE=creator/ros2/Dockerfile.${{ matrix.ros }}" >> $GITHUB_ENV
+      - name: Build ROS layer on MuJoCo
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ env.ROS_FILE }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/mujoco:${{ matrix.os }}
+
+  build-moveit-mujoco:
+    name: MuJoCo + ROS + MoveIt
+    runs-on: ubuntu-latest
+    needs: build-ros-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build MoveIt layer on MuJoCo
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/usage/Dockerfile.moveit
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+            ROS_DISTRO=${{ matrix.ros }}
+
+  build-nav2-mujoco:
+    name: MuJoCo + ROS + Nav2
+    runs-on: ubuntu-latest
+    needs: build-ros-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Nav2 layer on MuJoCo
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/usage/Dockerfile.nav2
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nav2:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+            ROS_DISTRO=${{ matrix.ros }}
+
+  finalize-base-ros-user:
+    name: Final User Image (ROS only)
+    runs-on: ubuntu-latest
+    needs: build-ros
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+          - { os: "22.04", ros: humble }
+          - { os: "20.04", ros: noetic }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final user image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}
+
+  finalize-base-ros-moveit-user:
+    name: Final User Image (MoveIt)
+    runs-on: ubuntu-latest
+    needs: build-moveit
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+          - { os: "22.04", ros: humble }
+          - { os: "20.04", ros: noetic }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final MoveIt image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-moveit
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}
+
+  finalize-mujoco-ros-user:
+    name: Final User Image (MuJoCo)
+    runs-on: ubuntu-latest
+    needs: build-ros-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+        matrix:
+          include:
+            - { os: "24.04", ros: kilted }
+            - { os: "24.04", ros: jazzy }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final MuJoCo image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ros:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+
+  finalize-mujoco-ros-moveit-user:
+    name: Final User Image (MuJoCo + MoveIt)
+    runs-on: ubuntu-latest
+    needs: build-moveit-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final MuJoCo MoveIt image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-moveit
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/moveit:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+
+  finalize-mujoco-ros-nav2-user:
+    name: Final User Image (MuJoCo + Nav2)
+    runs-on: ubuntu-latest
+    needs: build-nav2-mujoco
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - { os: "24.04", ros: rolling }
+          - { os: "24.04", ros: kilted }
+          - { os: "24.04", ros: jazzy }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build final MuJoCo Nav2 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: creator/common/Dockerfile.user
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os }}-${{ matrix.ros }}-mujoco-nav2
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nav2:${{ matrix.os }}-${{ matrix.ros }}-mujoco
+

--- a/creator/README.md
+++ b/creator/README.md
@@ -21,6 +21,15 @@
 - Example to run a Docker workspace with Ubuntu 22.04, ROS Humble, Navigation and Simulation enabled. However, you can attach your workspace to the container. This requires you to have a workspace in the same directory as the script. Or you can use the `-w` flag to specify the path to your workspace.
     - `./run_env.sh -o 22.04 -v humble -u navigation -s true -i my_image -w path_to_your_worspace -r`
 
+### Automated builds on GitHub
+ROS images are built and published using the
+[`ros2-staged.yml`](../.github/workflows/ros2-staged.yml) workflow. The workflow
+creates each layer in a separate job and pushes intermediate images. MuJoCo
+layers are only built for Ubuntu&nbsp;24.04, while other layers cover all valid
+Ubuntu and ROS combinations. MoveIt images are produced only for released ROS
+distributions (Jazzy, Kilted, Humble and Noetic) because the Rolling packages
+are sometimes missing.
+
 # Docker Workspaces using VSCode devcontainer
 =============================================
 - Create a new folder named `.devcontainer` in your workspace and creat a file named `devcontainer.json` in it.


### PR DESCRIPTION
## Summary
- restructure `ros2-staged.yml` so each job builds a single layer
- limit the MuJoCo layer to Ubuntu 24.04
- restrict MoveIt images to stable ROS distributions
- document the staged workflow in the README

## Testing
- `pre-commit run --files .github/workflows/ros2-staged.yml creator/README.md` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685eccdf6c388324a2702a5f09e1a9eb