### PR TITLE
Add GHCR cleanup workflow

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,19 @@
+name: GHCR Cleanup
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  delete-untagged-images:
+    name: Delete Untagged Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-untagged: true
+


### PR DESCRIPTION
## Summary
- add a scheduled GHCR cleanup workflow using dataaxiom/ghcr-cleanup-action

## Testing
- `pre-commit run --files .github/workflows/ghcr-cleanup.yml` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68629f8c63648324b699e8bbf0412a12